### PR TITLE
Avoid regression with Rails 8.1 initializers

### DIFF
--- a/lib/ruby_native/engine.rb
+++ b/lib/ruby_native/engine.rb
@@ -38,11 +38,11 @@ module RubyNative
       end
     end
 
-    initializer "ruby_native.oauth_middleware" do |app|
+    initializer "ruby_native.oauth_middleware", before: :build_middleware_stack do |app|
       app.middleware.insert_before ActionDispatch::Cookies, RubyNative::OAuthMiddleware
     end
 
-    initializer "ruby_native.tunnel_cookie_middleware" do |app|
+    initializer "ruby_native.tunnel_cookie_middleware", before: :build_middleware_stack do |app|
       if Rails.env.development?
         app.middleware.insert_before ActionDispatch::Cookies, RubyNative::TunnelCookieMiddleware
       end


### PR DESCRIPTION
This is similar to https://github.com/inertiajs/inertia-rails/pull/374 - rails/rails#53615 changed the initializers from an Array to a sorted graph. In absence of some care the initializer can end up in a spot where the middleware stack is already frozen, preventing any Rails app code from running - down to not being able to run bin/rails middleware or bin/rails g <any generator>.

The minimum viable fix seems to be to specify the initializer order so that it gets TSorted into the right spot, but it might be that this is a bona-fide larger regression with the new initializer graph approach.