### PR TITLE
Exclude OAuth paths from AASA universal links

### DIFF
--- a/app/controllers/ruby_native/aasa_controller.rb
+++ b/app/controllers/ruby_native/aasa_controller.rb
@@ -12,13 +12,30 @@ module RubyNative
       render json: {
         applinks: {
           details: [
-            { appIDs: [ app_id ], components: [ { "/": "*" } ] }
+            { appIDs: [ app_id ], components: oauth_exclusions + [ { "/": "*" } ] }
           ]
         },
         webcredentials: {
           apps: [ app_id ]
         }
       }
+    end
+
+    private
+
+    # OAuth redirects must stay inside ASWebAuthenticationSession. With the
+    # catch-all component alone, iOS treats the provider's redirect back to
+    # the app's domain (e.g. /users/auth/google_oauth2/callback) as a
+    # universal link, breaks out of the auth session, and native sign-in
+    # fails. Excluding the configured OAuth paths keeps the OAuth round-trip
+    # inside the session. The trailing `*` matches across `/`, so a start
+    # path also covers its `/callback` child. Components are evaluated in
+    # order and the first match wins, so exclusions go before the catch-all.
+    # See https://github.com/ruby-native/gem/issues/59.
+    def oauth_exclusions
+      Array(RubyNative.config&.dig(:auth, :oauth_paths)).map do |path|
+        { "/": "#{path}*", exclude: true }
+      end
     end
   end
 end

--- a/test/ruby_native/aasa_controller_test.rb
+++ b/test/ruby_native/aasa_controller_test.rb
@@ -25,13 +25,43 @@ class RubyNative::AasaControllerTest < ActionDispatch::IntegrationTest
     assert_equal({
       "applinks" => {
         "details" => [
-          { "appIDs" => [ "ABCD123456.com.example.test" ], "components" => [ { "/" => "*" } ] }
+          {
+            "appIDs" => [ "ABCD123456.com.example.test" ],
+            "components" => [
+              { "/" => "/auth/test_provider*", "exclude" => true },
+              { "/" => "*" }
+            ]
+          }
         ]
       },
       "webcredentials" => {
         "apps" => [ "ABCD123456.com.example.test" ]
       }
     }, body)
+  end
+
+  def test_excludes_each_configured_oauth_path_before_the_catch_all
+    RubyNative.config = RubyNative.config.deep_merge(
+      auth: { oauth_paths: [ "/users/auth/google_oauth2", "/users/auth/github" ] }
+    )
+
+    get PATH
+
+    components = JSON.parse(response.body).dig("applinks", "details", 0, "components")
+    assert_equal [
+      { "/" => "/users/auth/google_oauth2*", "exclude" => true },
+      { "/" => "/users/auth/github*", "exclude" => true },
+      { "/" => "*" }
+    ], components
+  end
+
+  def test_serves_only_the_catch_all_without_oauth_paths
+    RubyNative.config = RubyNative.config.deep_merge(auth: { oauth_paths: nil })
+
+    get PATH
+
+    components = JSON.parse(response.body).dig("applinks", "details", 0, "components")
+    assert_equal [ { "/" => "*" } ], components
   end
 
   def test_returns_404_when_ios_section_is_missing


### PR DESCRIPTION
Fixes #59.

## What

Native OAuth breaks when iOS intercepts the provider's redirect as a universal link: with `components: [{"/": "*"}]`, the redirect back to the app's domain (e.g. `/users/auth/google_oauth2/callback`) yanks the flow out of `ASWebAuthenticationSession` mid-sign-in. We hit this in production on Cora's TestFlight build — full verified chain and curl repro in #59.

This derives `exclude` components from the configured `auth.oauth_paths` and emits them ahead of the catch-all:

```json
"components": [
  { "/": "/users/auth/google_oauth2*", "exclude": true },
  { "/": "*" }
]
```

- Components are evaluated in order, first match wins — exclusions must precede the catch-all.
- The trailing `*` matches across `/`, so a start path also covers its `/callback` child.
- Apps with no `oauth_paths` get byte-identical AASA output to today.

## Testing

- Updated the exact-equality AASA test (the dummy app's `oauth_paths` now surfaces as an exclusion) and added cases for multiple paths + no-paths fallback. Full suite: 194 runs, 0 failures.
- Battle-tested in production shape: Cora currently ships this exact output via an app-side controller override ([EveryInc/cora#2670](https://github.com/EveryInc/cora/pull/2670)) — we'll drop the override once this lands in a release.

Not included (can follow up if you want it): the `StartController` `end_with?` provider-matching hardening mentioned in #59 — kept this PR to the AASA root cause.
