### PR TITLE
React: TypeScript types, NativeBackButton, and bridge helpers

### DIFF
--- a/packages/react/README.md
+++ b/packages/react/README.md
@@ -42,6 +42,15 @@ Each component renders a hidden `data-native-*` signal element that the Ruby Nat
 - `NativeSubmitButton` - native "Save" button that submits a form
 - `NativeOverscroll` - per-page overscroll colors
 - `NativeBadge` - set the badge count on a home screen or tab bar icon
+- `NativeFab` - floating action button (`icon`/`icons` required, plus `href` or `click`)
+- `NativeBackButton` - a visible button that pops the native navigation stack
+
+`NativeBackButton` renders a chevron by default and forwards any extra props (`className`, `aria-label`, `style`, ...) to the underlying `<button>`:
+
+```jsx
+<NativeBackButton aria-label="Go back" />
+<NativeBackButton>Back</NativeBackButton>
+```
 
 ## Helpers
 
@@ -50,6 +59,14 @@ Each component renders a hidden `data-native-*` signal element that the Ruby Nat
   ```jsx
   <button {...nativeHaptic("success")}>Save</button>
   ```
+
+- `nativePlatform()` - returns `"ios"`, `"android"`, or `null` (web / SSR), so you can branch on the native environment.
+- `nativePostMessage(message)` - send a message over the native bridge. Returns `false` (a no-op) on the web, during SSR, or before the wrapper is ready.
+- `nativeBack()` - pop the native navigation stack (what `NativeBackButton` calls).
+
+## TypeScript
+
+Type declarations ship with the package (`index.d.ts`) - no extra `@types` install needed.
 
 ## Docs
 

--- a/packages/react/index.d.ts
+++ b/packages/react/index.d.ts
@@ -1,0 +1,136 @@
+import * as React from "react"
+
+export type NativePlatform = "ios" | "android"
+
+/** Per-platform icon overrides, e.g. `{ ios: "bag", android: "shopping_cart" }`. */
+export interface NativeIcons {
+  ios?: string
+  android?: string
+}
+
+export interface NativeTabsProps {
+  /** Render the tab bar. Defaults to `true`. */
+  enabled?: boolean
+}
+export function NativeTabs(props: NativeTabsProps): React.ReactElement | null
+
+export function NativePush(): React.ReactElement
+
+export function NativeForm(): React.ReactElement
+
+export function NativeReview(): React.ReactElement
+
+export interface NativeNavbarProps {
+  /** Navigation bar title. */
+  title?: string
+  /** Enable pull-to-refresh on this page. Defaults to `true`. */
+  pullToRefresh?: boolean
+  /** `NativeButton` / `NativeSubmitButton` children to place in the bar. */
+  children?: React.ReactNode
+}
+export function NativeNavbar(props: NativeNavbarProps): React.ReactElement
+
+export interface NativeButtonProps {
+  /** Side of the navigation bar. Defaults to `"trailing"`. */
+  position?: "leading" | "trailing"
+  /** Icon name applied to every platform. */
+  icon?: string
+  /** Per-platform icon overrides; a matching entry wins over `icon`. */
+  icons?: NativeIcons
+  title?: string
+  /** Navigate to this URL on tap. */
+  href?: string
+  /** CSS selector to click on tap (alternative to `href`). */
+  click?: string
+  selected?: boolean
+  /** `NativeMenuItem` children turn the button into a menu. */
+  children?: React.ReactNode
+}
+export function NativeButton(props: NativeButtonProps): React.ReactElement
+
+export interface NativeMenuItemProps {
+  title?: string
+  href?: string
+  click?: string
+  icon?: string
+  icons?: NativeIcons
+  selected?: boolean
+}
+export function NativeMenuItem(props: NativeMenuItemProps): React.ReactElement
+
+export interface NativeFabProps {
+  /** Icon name applied to every platform. Required unless `icons` is given. */
+  icon?: string
+  /** Per-platform icon overrides; a matching entry wins over `icon`. */
+  icons?: NativeIcons
+  href?: string
+  click?: string
+}
+export function NativeFab(props: NativeFabProps): React.ReactElement
+
+export interface NativeOverscrollProps {
+  /** Top overscroll color. */
+  top: string
+  /** Bottom overscroll color. Defaults to `top`. */
+  bottom?: string
+}
+export function NativeOverscroll(props: NativeOverscrollProps): React.ReactElement
+
+export interface NativeSubmitButtonProps {
+  /** Button label. Defaults to `"Save"`. */
+  title?: string
+  /** CSS selector to click on tap. Defaults to `"[type='submit']"`. */
+  click?: string
+}
+export function NativeSubmitButton(props: NativeSubmitButtonProps): React.ReactElement
+
+export interface NativeBadgeProps {
+  /** Sets both `home` and `tab` when they are not given individually. */
+  count?: number
+  /** Home screen icon badge count. */
+  home?: number
+  /** Tab bar icon badge count. */
+  tab?: number
+}
+export function NativeBadge(props: NativeBadgeProps): React.ReactElement
+
+export interface NativeBackButtonProps extends React.ButtonHTMLAttributes<HTMLButtonElement> {
+  /** Custom button content. Defaults to a chevron icon. */
+  children?: React.ReactNode
+}
+/**
+ * A visible back button that pops the native navigation stack on tap. Extra
+ * props are forwarded to the underlying `<button>`. A supplied `onClick` runs
+ * first; calling `event.preventDefault()` in it cancels the native back.
+ */
+export function NativeBackButton(props: NativeBackButtonProps): React.ReactElement
+
+/** Returns the current native platform, or `null` on the web / during SSR. */
+export function nativePlatform(): NativePlatform | null
+
+/**
+ * Send a message over the native bridge. Returns `false` (a no-op) on the web,
+ * during SSR, or before the wrapper has injected `window.RubyNative`.
+ */
+export function nativePostMessage(message: unknown): boolean
+
+/** Pop the native navigation stack. Returns `false` when not in a native app. */
+export function nativeBack(): boolean
+
+/**
+ * Returns props to spread onto a clickable element so tapping it triggers
+ * native haptic feedback.
+ */
+export function nativeHaptic(
+  feedback?: string,
+  data?: Record<string, unknown>
+): Record<string, unknown> & { "data-native-haptic": string }
+
+declare global {
+  interface Window {
+    RubyNative?: {
+      postMessage(message: unknown): void
+      [key: string]: unknown
+    }
+  }
+}

--- a/packages/react/index.js
+++ b/packages/react/index.js
@@ -10,6 +10,26 @@ function rubyNativePlatform() {
   return null
 }
 
+// "ios" | "android" when running inside a Ruby Native wrapper, else null.
+export function nativePlatform() {
+  return rubyNativePlatform()
+}
+
+// Send a message over the native bridge. No-ops (returns false) on the web,
+// during SSR, or before the wrapper has injected `window.RubyNative`.
+export function nativePostMessage(message) {
+  if (typeof window === "undefined") return false
+  const bridge = window.RubyNative
+  if (!bridge || typeof bridge.postMessage !== "function") return false
+  bridge.postMessage(message)
+  return true
+}
+
+// Pop the native navigation stack. Mirrors `native_back_button_tag`.
+export function nativeBack() {
+  return nativePostMessage({ action: "back" })
+}
+
 function resolveIcon(icon, icons) {
   if (icons) {
     const platform = rubyNativePlatform()
@@ -97,6 +117,23 @@ export function NativeBadge({ count, home, tab }) {
   if (home != null) props["data-native-badge-home"] = home
   if (tab != null) props["data-native-badge-tab"] = tab
   return createElement("div", props)
+}
+
+// A visible back button that pops the native navigation stack on tap.
+// Renders a chevron by default; pass children to supply your own content.
+// Extra props (className, aria-label, style, ...) are forwarded to the button.
+export function NativeBackButton({ children, className, onClick, ...rest }) {
+  const classes = ["native-back-button", className].filter(Boolean).join(" ")
+  const handleClick = event => {
+    if (onClick) onClick(event)
+    if (!event.defaultPrevented) nativeBack()
+  }
+  const content = children != null ? children : createElement(
+    "svg",
+    { width: 24, height: 24, viewBox: "0 0 24 24", fill: "none", stroke: "currentColor", strokeWidth: 2.5, "aria-hidden": true },
+    createElement("path", { d: "M15.75 19.5L8.25 12l7.5-7.5", strokeLinecap: "round", strokeLinejoin: "round" })
+  )
+  return createElement("button", { type: "button", ...rest, className: classes, onClick: handleClick }, content)
 }
 
 export function nativeHaptic(feedback = "success", data = {}) {

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -3,7 +3,8 @@
   "version": "0.10.6",
   "description": "React components for Ruby Native",
   "main": "index.js",
-  "files": ["index.js", "README.md"],
+  "types": "index.d.ts",
+  "files": ["index.js", "index.d.ts", "README.md"],
   "peerDependencies": {
     "react": ">=18",
     "@inertiajs/react": ">=2"


### PR DESCRIPTION
## What

Brings `@ruby-native/react` to full parity with the Rails view helpers and gives consumers first-class TypeScript support. No build step or toolchain change — `index.js` stays hand-written JS.

### TypeScript types
- New `index.d.ts` with declarations for every export (typed props for all components, plus the helpers).
- `package.json` gains `"types": "index.d.ts"` and includes the file in `files`.
- Consumers get autocomplete and type-checking with no `@types` install.

### NativeBackButton
- A visible button that pops the native navigation stack on tap — the React counterpart of the Rails `native_back_button_tag`.
- Renders a chevron by default; accepts children and forwards extra props (`className`, `aria-label`, `style`, …) to the underlying `<button>`. A supplied `onClick` runs first and may `preventDefault()` to cancel the native back.

### Bridge helpers
- `nativePlatform()` → `"ios" | "android" | null`.
- `nativePostMessage(message)` — safe wrapper over `window.RubyNative.postMessage`; no-ops (returns `false`) on the web and during SSR.
- `nativeBack()` — convenience for `{ action: "back" }`.

### Docs
- Documents the previously undocumented `NativeFab`.
- Adds README sections for `NativeBackButton`, the bridge helpers, and TypeScript.

## Testing
- `node --check index.js` passes.
- Declarations type-check under `tsc --strict` (5.3.3) against `@types/react@18`, including JSX usage of the components; invalid props correctly error.

## Notes
- Version intentionally left at `0.10.6` — happy to bump (these are additive, so a minor) on request.
- The Vue package could get the same `NativeBackButton` / bridge helpers / types treatment in a follow-up if you'd like parity there too.