### PR TITLE
Take the preview port from PORT when it is set

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## Unreleased
+
+### Added
+
+- **`ruby_native preview` now takes its port from `PORT` when that is set.** `rails server` picks its port from `PORT`, and so does the `config/puma.rb` that ships with Rails, so an app on anything but 3000 meant passing `--port` on every preview to repeat a number the server already had. The precedence is the one `rails server` uses: `--port` wins, then `PORT`, then 3000. A `PORT` that is not a usable port number falls back to 3000, and every message that names the port says when it came from the environment.
+
 ## [0.12.1] - 2026-08-06
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -72,6 +72,8 @@ This starts a Cloudflare tunnel and shows a QR code for the Ruby Native app to s
 brew install cloudflare/cloudflare/cloudflared
 ```
 
+The tunnel points at port 3000, or at `PORT` when it is set, the same way `rails server` picks its port. Pass `--port 4000` to override, or `--url` for an upstream that isn't on localhost.
+
 See [rubynative.com/docs/cli](https://rubynative.com/docs/cli) for `deploy`, `login`, and auto-deploying from CI.
 
 ## React and Vue

--- a/lib/ruby_native/cli/preview.rb
+++ b/lib/ruby_native/cli/preview.rb
@@ -11,10 +11,12 @@ module RubyNative
       TUNNEL_READY_TIMEOUT = 60
       TUNNEL_POLL_INTERVAL = 1
       PUBLIC_NAMESERVERS = ["1.1.1.1", "8.8.8.8"].freeze
+      DEFAULT_PORT = 3000
+      PORT_RANGE = (1..65_535)
 
       def initialize(argv)
         @url = parse_option(argv, "--url")
-        @port = parse_port(argv)
+        @port, @port_from_env = resolve_port(argv)
         @upstream = @url || "http://localhost:#{@port}"
       end
 
@@ -57,7 +59,7 @@ module RubyNative
           puts ""
           puts "Make sure your Rails server is reachable at that URL."
         else
-          puts "Nothing is running on port #{@port}."
+          puts "Nothing is running on port #{port_description}."
           puts ""
           puts "Start your Rails server in another terminal:"
           puts "  bin/rails server -p #{@port}"
@@ -121,9 +123,29 @@ module RubyNative
         Process.clock_gettime(Process::CLOCK_MONOTONIC)
       end
 
-      def parse_port(argv)
-        value = parse_option(argv, "--port")
-        value ? value.to_i : 3000
+      # --port, then PORT, then 3000 is the precedence rails server itself uses,
+      # so a preview lands on the port the app is already serving. Anything
+      # unusable in PORT falls back rather than failing: the variable gets set
+      # for plenty of reasons that have nothing to do with a local Rails server.
+      def resolve_port(argv)
+        flag = parse_option(argv, "--port")
+        return [flag.to_i, false] if flag
+
+        env = env_port
+        env ? [env, true] : [DEFAULT_PORT, false]
+      end
+
+      def env_port
+        value = ENV["PORT"].to_s.strip
+        return unless value.match?(/\A\d+\z/)
+
+        port = value.to_i
+        port if PORT_RANGE.cover?(port)
+      end
+
+      # Naming the source keeps a port nobody typed from reading as a bug.
+      def port_description
+        @port_from_env ? "#{@port} (from PORT)" : @port.to_s
       end
 
       def parse_option(argv, flag)
@@ -148,7 +170,7 @@ module RubyNative
         if @url
           puts "Make sure your Rails server is reachable at #{@url}."
         else
-          puts "Make sure your Rails server is running on port #{@port} in another terminal."
+          puts "Make sure your Rails server is running on port #{port_description} in another terminal."
         end
         puts ""
 
@@ -201,7 +223,7 @@ module RubyNative
         if @url
           puts "Keep this running and your Rails server reachable at #{@url}."
         else
-          puts "Keep this running and your Rails server on port #{@port} in another terminal."
+          puts "Keep this running and your Rails server on port #{port_description} in another terminal."
         end
         puts "Press Ctrl+C to stop."
       end

--- a/test/ruby_native/cli/preview_test.rb
+++ b/test/ruby_native/cli/preview_test.rb
@@ -6,6 +6,54 @@ class PreviewTest < Minitest::Test
     @preview = RubyNative::CLI::Preview.new(["--port", "3000"])
   end
 
+  def test_defaults_to_port_3000
+    with_port(nil) { assert_equal "http://localhost:3000", upstream_for([]) }
+  end
+
+  def test_takes_the_port_from_the_environment
+    with_port("3001") { assert_equal "http://localhost:3001", upstream_for([]) }
+  end
+
+  def test_port_flag_wins_over_the_environment
+    with_port("3001") { assert_equal "http://localhost:4000", upstream_for(["--port", "4000"]) }
+  end
+
+  def test_url_flag_ignores_the_environment
+    with_port("3001") { assert_equal "https://app.test", upstream_for(["--url", "https://app.test"]) }
+  end
+
+  def test_unusable_environment_ports_fall_back_to_the_default
+    ["", "  ", "tcp://10.0.0.1:3001", "3001abc", "0", "99999"].each do |value|
+      with_port(value) do
+        assert_equal "http://localhost:3000", upstream_for([]), "PORT=#{value.inspect}"
+      end
+    end
+  end
+
+  def test_messages_name_the_environment_as_the_source_of_an_inherited_port
+    with_port("3001") do
+      preview = RubyNative::CLI::Preview.new([])
+      preview.define_singleton_method(:fetch_config_response) { |_uri| raise Errno::ECONNREFUSED }
+      out, _err = capture_io do
+        assert_raises(SystemExit) { preview.send(:check_upstream!) }
+      end
+      assert_match(/Nothing is running on port 3001 \(from PORT\)/, out)
+      assert_match(/bin\/rails server -p 3001/, out)
+    end
+  end
+
+  # The QR screen is the last thing printed, seconds after the same port was
+  # named with its source, so it has to agree.
+  def test_the_qr_reminder_names_the_environment_as_the_source_too
+    with_port("3001") do
+      preview = RubyNative::CLI::Preview.new([])
+      out, _err = capture_io do
+        preview.send(:display_qr, "https://example.trycloudflare.com")
+      end
+      assert_match(/your Rails server on port 3001 \(from PORT\)/, out)
+    end
+  end
+
   def test_passes_when_config_endpoint_returns_200
     stub_http_response(Net::HTTPSuccess.new("1.1", "200", "OK"))
     @preview.send(:check_upstream!)
@@ -52,6 +100,7 @@ class PreviewTest < Minitest::Test
       assert_raises(SystemExit) { @preview.send(:check_upstream!) }
     end
     assert_match(/Nothing is running on port 3000/, out)
+    refute_match(/from PORT/, out)
   end
 
   def test_exits_when_url_unreachable
@@ -189,6 +238,18 @@ class PreviewTest < Minitest::Test
   end
 
   private
+
+  def upstream_for(argv)
+    RubyNative::CLI::Preview.new(argv).instance_variable_get(:@upstream)
+  end
+
+  def with_port(value)
+    original = ENV["PORT"]
+    ENV["PORT"] = value
+    yield
+  ensure
+    ENV["PORT"] = original
+  end
 
   def stub_http_response(response)
     @preview.define_singleton_method(:fetch_config_response) { |_uri| response }


### PR DESCRIPTION
`ruby_native preview` always assumes port 3000. My dev server runs on 3001, so every preview means typing `--port 3001` to repeat a number the server already has.

`rails server` picks its port from `PORT` ([railties](https://github.com/rails/rails/blob/main/railties/lib/rails/commands/server/server_command.rb): `options[:port] || ENV.fetch("PORT", DEFAULT_PORT).to_i`), and so does the `config/puma.rb` that ships with Rails. This makes `preview` follow the same rule instead of inventing its own.

Precedence is the one `rails server` uses: `--port` wins, then `PORT`, then 3000.

A `PORT` that is not a usable port number (blank, not a number, out of range) falls back to 3000. The variable gets set for plenty of reasons that have nothing to do with a local Rails server, and none of them should stop a preview from starting.

Every message that names the port says when it came from the environment, so a port nobody typed does not read as a bug:

```
Nothing is running on port 3001 (from PORT).

Start your Rails server in another terminal:
  bin/rails server -p 3001
```

### Worth your call

`PORT` is a widely used variable. Anyone who has it exported for an unrelated reason will get a different preview port than they got before. That is inherent to the feature, and it is why the fallback and the `(from PORT)` note exist, but it is a behavior change for existing users and you may prefer it opt-in.

### Testing

`bundle exec rake test` passes (293 runs, 896 assertions, 0 failures), with `PORT` set and unset. New tests cover the default, the env var, `--port` precedence, `--url`, the unusable-value fallbacks, and the annotation on both message paths.

I also ran the real `ruby_native preview` command for all four resolution cases, with a stand-in for `cloudflared` so no public tunnel was opened. Not tested on macOS.

A CHANGELOG entry under Unreleased and a line in the README are included.
