### PR TITLE
Load the config on first read, not at boot

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## Unreleased
+
+### Fixed
+
+- **`assets:precompile` no longer drops the built bundles from the Propshaft manifest when `config/ruby_native.yml` uses an asset helper such as `image_url`.** Every page 500ed after deploy. The config now loads on the first request instead of at boot, so a YAML or ERB error in it surfaces there rather than failing boot.
+
 ## [0.15.2] - 2026-08-28
 
 ### Fixed

--- a/lib/ruby_native.rb
+++ b/lib/ruby_native.rb
@@ -1,4 +1,5 @@
 require "erb"
+require "monitor"
 require "ruby_native/version"
 require "ruby_native/helper"
 require "ruby_native/native_version"
@@ -16,7 +17,6 @@ require "ruby_native/screenshots/sign_in_helper"
 require "ruby_native/engine"
 
 module RubyNative
-  mattr_accessor :config
   mattr_accessor :subscription_callbacks, default: []
 
   # Screenshot configuration. Set via `RubyNative.configure` in an initializer.
@@ -41,6 +41,26 @@ module RubyNative
     subscription_callbacks.each { |cb| cb.call(event) }
   end
 
+  CONFIG_LOCK = Monitor.new
+  private_constant :CONFIG_LOCK
+
+  # Loaded on first read, not at boot: rendering the YAML's ERB runs asset
+  # helpers, and under `assets:precompile` those run before the bundles are
+  # built, leaving Propshaft's manifest without them.
+  def self.config
+    return @config if defined?(@config)
+
+    CONFIG_LOCK.synchronize do
+      load_config unless defined?(@config)
+      @config = nil unless defined?(@config) # missing or empty file
+      @config
+    end
+  end
+
+  def self.config=(value)
+    @config = value
+  end
+
   def self.load_config
     path = Rails.root.join("config", "ruby_native.yml")
     return unless path.exist?
@@ -48,7 +68,7 @@ module RubyNative
     parsed = YAML.load(render_config(path), filename: path.to_s, aliases: true)
 
     # An empty file, comments only, or ERB rendering to nothing parses to nil;
-    # treat it like a missing file instead of crashing Rails boot.
+    # treat it like a missing file instead of raising.
     unless parsed.is_a?(Hash)
       Rails.logger.warn("[RubyNative] #{path} is empty or not a YAML mapping; ignoring it.")
       return

--- a/lib/ruby_native/engine.rb
+++ b/lib/ruby_native/engine.rb
@@ -32,12 +32,6 @@ module RubyNative
       end
     end
 
-    initializer "ruby_native.config" do
-      config.after_initialize do
-        RubyNative.load_config
-      end
-    end
-
     initializer "ruby_native.oauth_middleware", before: :build_middleware_stack do |app|
       app.middleware.insert_before ActionDispatch::Cookies, RubyNative::OAuthMiddleware
     end

--- a/test/ruby_native/config_test.rb
+++ b/test/ruby_native/config_test.rb
@@ -1,9 +1,30 @@
 require "test_helper"
 
 class RubyNative::ConfigTest < Minitest::Test
+  def teardown
+    RubyNative.load_config
+  end
+
   def test_load_config_reads_yaml
     RubyNative.load_config
     refute_nil RubyNative.config
+  end
+
+  def test_config_is_not_loaded_while_rails_boots
+    refute CONFIG_LOADED_AT_BOOT, "the dummy app read RubyNative.config during boot"
+  end
+
+  def test_config_loads_on_first_read
+    RubyNative.load_config
+    RubyNative.remove_instance_variable(:@config)
+
+    assert_equal "Test App", RubyNative.config[:app][:name]
+  end
+
+  def test_a_nil_config_is_not_reloaded_on_read
+    RubyNative.config = nil
+
+    assert_nil RubyNative.config
   end
 
   def test_config_is_deep_symbolized

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -41,6 +41,9 @@ require "active_record"
 
 Dummy::Application.initialize!
 
+# Captured before any test reads the config; see RubyNative.config.
+CONFIG_LOADED_AT_BOOT = RubyNative.instance_variable_defined?(:@config)
+
 # Explicitly require the model since engine autoloading may not work in the minimal dummy app.
 require_relative "../app/models/ruby_native/iap/purchase_intent"
 


### PR DESCRIPTION
`RubyNative.load_config` ran in `after_initialize`, rendering `config/ruby_native.yml`'s ERB against the asset helpers. An `image_url` in the file (the documented navbar-logo case) made Propshaft build and cache its map of the load path while Rails booted. Under `assets:precompile` that happens before `css:build` and `javascript:build` have written `app/assets/builds` — they are prerequisites that run after `environment`. Propshaft then wrote the manifest from the stale map: `application.css` was missing and `application.js` pointed at its source file, so every page 500ed with `Propshaft::MissingAssetError` after deploy.

Heroku escapes because its Node buildpack runs `yarn build` before Rails boots; a Dockerfile that runs `assets:precompile` on its own (Cloud Run, Kamal) hits it.

**Fix:** `RubyNative.config` now loads lazily on its first read, so nothing touches the asset pipeline during boot. A missing or empty file still keeps whatever was already loaded, as before. A YAML or ERB error surfaces on the first request instead of failing boot.

**Reproduction** (Rails app with propshaft + cssbundling + `image_url` in `ruby_native.yml`):

```
rm -rf app/assets/builds/* public/assets
RAILS_ENV=production SECRET_KEY_BASE_DUMMY=1 bin/rails assets:precompile
grep -c '"application.css"' public/assets/.manifest.json
```

Prints `0` on 0.15.2 and `1` with this branch; `application.js` maps to the built bundle instead of the source file.

Tests: 408 runs, 0 failures. Added a boot-time check in `test_helper.rb` that fails if anything reads the config while the dummy app boots, plus two tests for the lazy read.
